### PR TITLE
Fix issue with wrong unit when there's more than 3 ingredients

### DIFF
--- a/src/pha/swissmedic1.cpp
+++ b/src/pha/swissmedic1.cpp
@@ -442,7 +442,7 @@ std::string getDosageFromName(const std::string &name)
         dosage = match[0];
 
     std::string dosage2;
-    std::regex rgx2(R"((\d+)(\.\d+)?\/(\d+)(\.\d+)?\s*(Ds|ds|mg)?)");  // tested at https://regex101.com
+    std::regex rgx2(R"(((\d+)(\.\d+)?(Ds|ds|mg)?)(\/(\d+)(\.\d+)?(Ds|ds|mg|ml|mg|g)?)+)");  // tested at https://regex101.com
     if (std::regex_search(name, match, rgx2))
         dosage2 = match[0];
 

--- a/src/zur/voll.cpp
+++ b/src/zur/voll.cpp
@@ -93,7 +93,7 @@ std::string parseUnitFromTitle(const std::string &pack_title)
     }
 
     std::string dosage2;
-    std::regex rgx2(R"((\d+)(\.\d+)?\/(\d+)(\.\d+)?\s*(Ds|ds|mg)?)");  // tested at https://regex101.com
+    std::regex rgx2(R"(((\d+)(\.\d+)?(Ds|ds|mg)?)(\/(\d+)(\.\d+)?(Ds|ds|mg|ml|mg|g)?)+)");  // tested at https://regex101.com
     if (std::regex_search(pack_title, match, rgx2)) {
         dosage2 = match[0];
     }


### PR DESCRIPTION
https://github.com/zdavatz/smart-order/issues/65

Wir haben ein Problem mit 3 Wirkstoffen.  "5mg/160mg/25mg" ist nicht anerkannt, die Databank hat "5mg/160mg" anstelle. Diese PR sollt das reparieren