### PR TITLE
Fix unit regex to include space

### DIFF
--- a/src/zur/voll.cpp
+++ b/src/zur/voll.cpp
@@ -94,7 +94,7 @@ std::string parseUnitFromTitle(const std::string &pack_title)
     }
 
     std::string dosage2;
-    std::regex rgx2(R"(((\d+)(\.\d+)?(Ds|ds|mg)?)(\/(\d+)(\.\d+)?(Ds|ds|mg|ml|mg|g)?)+)");  // tested at https://regex101.com
+    std::regex rgx2(R"(((\d+)(\.\d+)?(Ds|ds|mg)?)(\/(\d+)(\.\d+)?\s*(Ds|ds|mg|ml|mg|g)?)+)");  // tested at https://regex101.com
     if (std::regex_search(pack_title, match, rgx2)) {
         dosage2 = match[0];
     }


### PR DESCRIPTION
https://github.com/zdavatz/smart-order/issues/134